### PR TITLE
[SEC-1336] Add Semgrep Github Action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,10 @@
+name: Semgrep
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '50 5 * * 4' 
+jobs:
+  call-semgrep:
+    uses: trayio/semgrep-reusable-workflow/.github/workflows/semgrep.yml@main
+    secrets: inherit


### PR DESCRIPTION

# Description

This PR is to add the Static Application Security Testing (SAST) tool Semgrep Github Action. This will run a scheduled scan of the repository on a weekly basis and send the findings to Semgrep.

Further information if needed - [Github Action Documentation](https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#github-actions)