### PR TITLE
[EE-3024] badges script update

### DIFF
--- a/scripts/updateTestCoverage.js
+++ b/scripts/updateTestCoverage.js
@@ -1,7 +1,7 @@
-const fetch = require("node-fetch")
 const {parseCoverageFromFile} = require("./parseCoverageFromFile")
 
-const sendCoverageDataToTrayWorkflow = (coverageData) => {
+const sendCoverageDataToTrayWorkflow = async (coverageData) => {
+    const fetch = (await import("node-fetch")).default
     fetch("https://1141188d-d67c-46f9-a6c6-1369999bf294.trayapp.io", {
         method: "POST",
         body: JSON.stringify(coverageData),
@@ -13,5 +13,9 @@ const sendCoverageDataToTrayWorkflow = (coverageData) => {
     })
 }
 
-const coverageData = parseCoverageFromFile()
-sendCoverageDataToTrayWorkflow(coverageData)
+const main = async () => {
+    const coverageData = parseCoverageFromFile()
+    await sendCoverageDataToTrayWorkflow(coverageData)
+}
+
+main().catch(console.error)


### PR DESCRIPTION
This pull request updates the `scripts/updateTestCoverage.js` script to improve how it handles asynchronous operations and module loading. The main changes involve converting the coverage data sending function to use async/await and dynamically importing the `node-fetch` module only when needed.

**Improvements to asynchronous handling and module loading:**

* Refactored `sendCoverageDataToTrayWorkflow` to be an async function and use dynamic import for `node-fetch`, ensuring compatibility with newer Node.js versions and avoiding top-level require issues.
* Updated the script entry point to use an async `main` function and properly await the sending of coverage data, with error handling via `.catch(console.error)`.