### PR TITLE
subscription support

### DIFF
--- a/scripts/updateTestCoverage.js
+++ b/scripts/updateTestCoverage.js
@@ -18,4 +18,5 @@ const main = async () => {
     await sendCoverageDataToTrayWorkflow(coverageData)
 }
 
+// eslint-disable-next-line no-console
 main().catch(console.error)

--- a/src/test/full_functionality.spec.ts
+++ b/src/test/full_functionality.spec.ts
@@ -469,6 +469,260 @@ describe("Mutations", () => {
     })
 })
 
+describe("Subscriptions", () => {
+    it("Simple subscription", () => {
+        const subscription = `
+            subscription {
+                messageAdded {
+                    id
+                    content
+                    user {
+                        name
+                        email
+                    }
+                }
+            }
+        `
+        expect(graphQlQueryToJson(subscription)).toEqual({
+            subscription: {
+                messageAdded: {
+                    id: true,
+                    content: true,
+                    user: {
+                        name: true,
+                        email: true,
+                    },
+                },
+            },
+        })
+    })
+
+    it("Subscription with arguments", () => {
+        const subscription = `
+            subscription MessageSubscription($userId: ID!) {
+                messageAdded(userId: $userId) {
+                    id
+                    content
+                    timestamp
+                }
+            }
+        `
+        const result = graphQlQueryToJson(subscription, {
+            variables: {
+                userId: "123",
+            },
+        })
+        expect(result).toEqual({
+            subscription: {
+                messageAdded: {
+                    __args: {
+                        userId: "123",
+                    },
+                    id: true,
+                    content: true,
+                    timestamp: true,
+                },
+            },
+        })
+    })
+
+    it("Subscription with alias", () => {
+        const subscription = `
+            subscription {
+                latestMessage: messageAdded {
+                    id
+                    content
+                }
+            }
+        `
+        expect(graphQlQueryToJson(subscription)).toEqual({
+            subscription: {
+                latestMessage: {
+                    __aliasFor: "messageAdded",
+                    id: true,
+                    content: true,
+                },
+            },
+        })
+    })
+
+    it("Subscription with enum arguments", () => {
+        const subscription = `
+            subscription {
+                messageAdded(channel: PUBLIC, priority: HIGH) {
+                    id
+                    content
+                }
+            }
+        `
+        expect(graphQlQueryToJson(subscription)).toEqual({
+            subscription: {
+                messageAdded: {
+                    __args: {
+                        channel: new EnumType("PUBLIC"),
+                        priority: new EnumType("HIGH"),
+                    },
+                    id: true,
+                    content: true,
+                },
+            },
+        })
+    })
+
+    it("Subscription with scalar field with arguments", () => {
+        const subscription = `
+            subscription {
+                messageCount(channel: "general", since: "2024-01-01")
+            }
+        `
+        expect(graphQlQueryToJson(subscription)).toEqual({
+            subscription: {
+                messageCount: {
+                    __args: {
+                        channel: "general",
+                        since: "2024-01-01",
+                    },
+                },
+            },
+        })
+    })
+
+    it("Subscription with nested objects and complex arguments", () => {
+        const subscription = `
+            subscription NotificationSubscription($input: NotificationInput!) {
+                notificationAdded(input: $input) {
+                    id
+                    message
+                    user {
+                        id
+                        name
+                        profile {
+                            avatar
+                        }
+                    }
+                    metadata {
+                        priority
+                        tags
+                    }
+                }
+            }
+        `
+        const result = graphQlQueryToJson(subscription, {
+            variables: {
+                input: {
+                    userId: "123",
+                    channels: ["email", "push"],
+                    filters: {
+                        priority: "high",
+                        categories: ["system", "user"],
+                    },
+                },
+            },
+        })
+        expect(result).toEqual({
+            subscription: {
+                notificationAdded: {
+                    __args: {
+                        input: {
+                            userId: "123",
+                            channels: ["email", "push"],
+                            filters: {
+                                priority: "high",
+                                categories: ["system", "user"],
+                            },
+                        },
+                    },
+                    id: true,
+                    message: true,
+                    user: {
+                        id: true,
+                        name: true,
+                        profile: {
+                            avatar: true,
+                        },
+                    },
+                    metadata: {
+                        priority: true,
+                        tags: true,
+                    },
+                },
+            },
+        })
+    })
+
+    it("Subscription with directives (directives are ignored)", () => {
+        const subscription = `
+            subscription MessageSubscription($includeUser: Boolean!) {
+                messageAdded {
+                    id
+                    content
+                    user @include(if: $includeUser) {
+                        name
+                    }
+                }
+            }
+        `
+        const result = graphQlQueryToJson(subscription, {
+            variables: {
+                includeUser: true,
+            },
+        })
+        expect(result).toEqual({
+            subscription: {
+                messageAdded: {
+                    id: true,
+                    content: true,
+                    user: {
+                        name: true,
+                    },
+                },
+            },
+        })
+    })
+
+    it("Should throw error for subscription with named fragments", () => {
+        const subscriptionWithFragment = `
+            subscription {
+                messageAdded {
+                    ...MessageFields
+                }
+            }
+
+            fragment MessageFields on Message {
+                id
+                content
+                user {
+                    name
+                }
+            }
+        `
+        expect(() => {
+            graphQlQueryToJson(subscriptionWithFragment)
+        }).toThrow("The parsed query has more than one set of definitions")
+    })
+
+    it("Should throw error for subscription with inline fragments", () => {
+        const subscriptionWithInlineFragment = `
+            subscription {
+                messageAdded {
+                    id
+                    content
+                    ... on TextMessage {
+                        text
+                    }
+                    ... on ImageMessage {
+                        imageUrl
+                        caption
+                    }
+                }
+            }
+        `
+        expect(() => {
+            graphQlQueryToJson(subscriptionWithInlineFragment)
+        }).toThrow()
+    })
+})
+
 describe("Aliases", () => {
     it("Simple example with aliases", () => {
         const query = `

--- a/src/test/readme_examples.spec.ts
+++ b/src/test/readme_examples.spec.ts
@@ -440,4 +440,95 @@ query SearchContent(
             })
         })
     })
+
+    describe("11. Subscriptions", () => {
+        it("Basic subscription", () => {
+            const subscription = `
+subscription {
+    messageAdded {
+        id
+        content
+        user {
+            name
+            email
+        }
+    }
+}
+`
+
+            const result = graphQlQueryToJson(subscription)
+
+            expect(result).toEqual({
+                subscription: {
+                    messageAdded: {
+                        id: true,
+                        content: true,
+                        user: {
+                            name: true,
+                            email: true,
+                        },
+                    },
+                },
+            })
+        })
+
+        it("Subscription with variables and arguments", () => {
+            const subscription = `
+subscription MessageSubscription($userId: ID!, $channel: String!) {
+    messageAdded(userId: $userId, channel: $channel) {
+        id
+        content
+        timestamp
+    }
+}
+`
+
+            const result = graphQlQueryToJson(subscription, {
+                variables: {
+                    userId: "123",
+                    channel: "general",
+                },
+            })
+
+            expect(result).toEqual({
+                subscription: {
+                    messageAdded: {
+                        __args: {
+                            userId: "123",
+                            channel: "general",
+                        },
+                        id: true,
+                        content: true,
+                        timestamp: true,
+                    },
+                },
+            })
+        })
+
+        it("Subscription with aliases and enums", () => {
+            const subscription = `
+subscription {
+    latestMessage: messageAdded(channel: PUBLIC) {
+        id
+        content
+    }
+}
+`
+
+            const result = graphQlQueryToJson(subscription)
+
+            expect(result).toEqual({
+                subscription: {
+                    latestMessage: {
+                        __aliasFor: "messageAdded",
+                        __args: {
+                            channel: {value: "PUBLIC"},
+                        },
+                        id: true,
+                        content: true,
+                    },
+                },
+            })
+        })
+    })
 })


### PR DESCRIPTION
This is to address some comments made in https://github.com/trayio/graphql-query-to-json/pull/48 about lack of subscription support.

This pull request adds comprehensive support and documentation for GraphQL subscriptions to the `graphQlQueryToJson` library, along with extensive test coverage and clarification of current limitations. The most important changes are grouped below:

**Subscription Support and Documentation:**

* Added a new section to the `README.md` with usage examples for GraphQL subscriptions, including basic subscriptions, subscriptions with variables/arguments, aliases, and enums. The API reference was updated to clarify that the `query` parameter now accepts subscription strings.
* Added a "Limitations" section to the documentation detailing unsupported features such as named and inline fragments, and the handling of directives (parsed but ignored).

**Test Coverage:**

* Added a new `describe("Subscriptions", ...)` block to `src/test/full_functionality.spec.ts` with thorough test cases covering simple subscriptions, arguments, aliases, enums, nested objects, directives, and error handling for unsupported fragments.
* Added corresponding subscription example tests to `src/test/readme_examples.spec.ts` to ensure README examples are validated by tests.

**Minor Improvements:**

* Added an ESLint directive to suppress console warnings in `scripts/updateTestCoverage.js`.